### PR TITLE
Take unit setting from grill status

### DIFF
--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -61,7 +61,7 @@ class ValueTemperature(IntegrationBlueprintEntity):
 
     @property
     def unit_of_measurement(self):
-        return "ºF"
+        return self.client.get_units_for_device(self.grill_id)
 
 
 class AccessoryTemperatureSensor(IntegrationBlueprintEntity):
@@ -99,4 +99,4 @@ class AccessoryTemperatureSensor(IntegrationBlueprintEntity):
 
     @property
     def unit_of_measurement(self):
-        return "ºF"
+        return self.client.get_units_for_device(self.grill_id)

--- a/custom_components/traeger/traeger.py
+++ b/custom_components/traeger/traeger.py
@@ -21,6 +21,7 @@ import socket
 import logging
 import async_timeout
 import aiohttp
+import homeassistant.const
 
 
 CLIENT_ID = "2fuohjtqv1e63dckp5v84rau0j"
@@ -157,6 +158,7 @@ class traeger:
         return self.mqtt_client
 
     def grill_message(self, client, userdata, message):
+        _LOGGER.info("grill_message: message.topic = %s, message.payload = %s", message.topic, message.payload)
         if message.topic.startswith("prod/thing/update/"):
             grill_id = message.topic[len("prod/thing/update/"):]
             self.grill_status[grill_id] = json.loads(message.payload)
@@ -194,6 +196,15 @@ class traeger:
         if thingName not in self.grill_status:
             return None
         return self.grill_status[thingName]["settings"]
+
+    def get_units_for_device(self, thingName):
+        state = self.get_state_for_device(thingName)
+        if state is None:
+            return homeassistant.const.TEMP_FAHRENHEIT
+        if state["units"] == 0:
+            return homeassistant.const.TEMP_CELSIUS
+        else:
+            return homeassistant.const.TEMP_FAHRENHEIT
 
     def get_details_for_accessory(self, thingName, accessory_id):
         state = self.get_state_for_device(thingName)

--- a/custom_components/traeger/water_heater.py
+++ b/custom_components/traeger/water_heater.py
@@ -69,7 +69,10 @@ class IntegrationBlueprintBinarySensor(WaterHeaterEntity, IntegrationBlueprintEn
     @property
     def min_temp(self):
         # this was the min the traeger app would let me set
-        return 165
+        if self.client.get_units_for_device(self.grill_id) == TEMP_CELSIUS:
+            return 75
+        else:
+            return 165
 
     @property
     def max_temp(self):
@@ -85,7 +88,10 @@ class IntegrationBlueprintBinarySensor(WaterHeaterEntity, IntegrationBlueprintEn
 
     @property
     def temperature_unit(self):
-        return TEMP_FAHRENHEIT
+        if self.client.get_units_for_device(self.grill_id) == TEMP_CELSIUS:
+            return TEMP_CELSIUS
+        else:
+            return TEMP_FAHRENHEIT
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""


### PR DESCRIPTION
Great work on the integration. It already made my Traeger like 100% more useful because I can actually get a temperature log now :)

However, I have set my grill to use °C as temperature unit which currently leads to temperature numbers displayed wrong: Some values are converted from °C to °C again, while for some just the displayed unit is wrong.
This PR should take the unit as defined in the grill.
I only could do a small test while cooking my New Year's Eve ribs, so please test with a grill set to F to verify.

I've also snuck in some debug output of the MQTT messages :)

Again, thank you very much for your great work. As time allows, I try to help with coding :)