### PR TITLE
Pellet Level Sensor + Other Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Component to integrate with [Traeger WiFire Grills][traeger]._
 Platform | Description
 -- | --
 `sensor` | Shows various temperature readings from the grill or accessories
-`water_heater` | Allows temperature control of the grill
+`climate` | Allows temperature control of the grill
 
 ![device][deviceimg]
 ![grill][grillimg]

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -1,4 +1,4 @@
-"""Binary sensor platform for integration_blueprint."""
+"""Climate platform for Traeger grills"""
 
 import logging
 
@@ -20,6 +20,14 @@ from homeassistant.const import (
 from .const import (
     DEFAULT_NAME,
     DOMAIN,
+    GRILL_MODE_OFFLINE,
+    GRILL_MODE_COOL_DOWN,
+    GRILL_MODE_CUSTOM_COOK,
+    GRILL_MODE_MANUAL_COOK,
+    GRILL_MODE_PREHEATING,
+    GRILL_MODE_IGNITING,
+    GRILL_MODE_IDLE,
+    GRILL_MODE_SLEEPING,
 )
 
 from .entity import IntegrationBlueprintEntity
@@ -31,29 +39,40 @@ async def async_setup_entry(hass, entry, async_add_devices):
     client = hass.data[DOMAIN][entry.entry_id]
     grills = client.get_grills()
     for grill in grills:
-        async_add_devices(
-            [IntegrationBlueprintBinarySensor(client, grill["thingName"])]
-        )
+        async_add_devices([TraegerClimateEntity(client, grill["thingName"])])
 
 
-class IntegrationBlueprintBinarySensor(ClimateEntity, IntegrationBlueprintEntity):
-    """integration_blueprint binary_sensor class."""
-
-    def grill_update(self):
-        self.schedule_update_ha_state()
+class TraegerClimateEntity(ClimateEntity, IntegrationBlueprintEntity):
+    """Climate entity for Traeger grills"""
 
     def __init__(self, client, grill_id):
         self.grill_id = grill_id
         self.client = client
+        self.grill_details = None
+        self.grill_state = None
+        self.grill_units = None
+        self.grill_limits = None
+
+        # Tell the Traeger client to call grill_update() when it gets an update
         self.client.set_callback_for_grill(self.grill_id, self.grill_update)
 
+    def grill_update(self):
+        """This gets called when the grill has an update. Update state variable"""
+        self.grill_details = self.client.get_details_for_device(self.grill_id)
+        self.grill_state = self.client.get_state_for_device(self.grill_id)
+        self.grill_units = self.client.get_units_for_device(self.grill_id)
+        self.grill_limits = self.client.get_limits_for_device(self.grill_id)
+
+        # Tell HA we have an update
+        self.schedule_update_ha_state()
+
+    # Generic Properties
     @property
     def name(self):
-        """Return the name of the binary_sensor."""
-        state = self.client.get_details_for_device(self.grill_id)
-        if state is None:
+        """Return the name of the grill"""
+        if self.grill_details is None:
             return f"{self.grill_id}"
-        return state["friendlyName"]
+        return self.grill_details["friendlyName"]
 
     @property
     def unique_id(self):
@@ -63,68 +82,65 @@ class IntegrationBlueprintBinarySensor(ClimateEntity, IntegrationBlueprintEntity
     def icon(self):
         return "mdi:grill"
 
+    # Climate Properties
+    @property
+    def temperature_unit(self):
+        if self.grill_units == TEMP_CELSIUS:
+            return TEMP_CELSIUS
+        else:
+            return TEMP_FAHRENHEIT
+
     @property
     def current_temperature(self):
-        state = self.client.get_state_for_device(self.grill_id)
-        if state is None:
+        if self.grill_state is None:
             return 0
-        return state["grill"]
+        return self.grill_state["grill"]
 
     @property
     def target_temperature(self):
-        state = self.client.get_state_for_device(self.grill_id)
-        if state is None:
+        if self.grill_state is None:
             return 0
-        return state["set"]
+        return self.grill_state["set"]
+
+    @property
+    def max_temp(self):
+        if self.grill_limits is None:
+            return self.min_temp
+        return self.grill_limits["max_grill_temp"]
 
     @property
     def min_temp(self):
         # this was the min the traeger app would let me set
-        if self.client.get_units_for_device(self.grill_id) == TEMP_CELSIUS:
+        if self.grill_units == TEMP_CELSIUS:
             return 75
         else:
             return 165
-
-    @property
-    def max_temp(self):
-        limits = self.client.get_limits_for_device(self.grill_id)
-        if limits is None:
-            return self.min_temp
-        return limits["max_grill_temp"]
-
-    @property
-    def supported_features(self):
-        """Return the list of supported features for the grill"""
-        return SUPPORT_TARGET_TEMPERATURE
-
-    @property
-    def temperature_unit(self):
-        if self.client.get_units_for_device(self.grill_id) == TEMP_CELSIUS:
-            return TEMP_CELSIUS
-        else:
-            return TEMP_FAHRENHEIT
 
     @property
     def hvac_mode(self):
         """Return hvac operation ie. heat, cool mode.
         Need to be one of HVAC_MODE_*.
         """
-        state = self.client.get_state_for_device(self.grill_id)
-        if state is None:
+        if self.grill_state is None:
             return HVAC_MODE_OFF
-        elif state["system_status"] == 8:  # Cool Down
+
+        state = self.grill_state["system_status"]
+
+        if state == GRILL_MODE_COOL_DOWN:  # Cool Down
             return HVAC_MODE_COOL
-        elif state["system_status"] == 7:  # Custom Cook
+        elif state == GRILL_MODE_CUSTOM_COOK:  # Custom Cook
             return HVAC_MODE_HEAT
-        elif state["system_status"] == 6:  # Manual Cook
+        elif state == GRILL_MODE_MANUAL_COOK:  # Manual Cook
             return HVAC_MODE_HEAT
-        elif state["system_status"] == 5:  # Preheating
+        elif state == GRILL_MODE_PREHEATING:  # Preheating
             return HVAC_MODE_HEAT
-        elif state["system_status"] == 4:  # Igniting
+        elif state == GRILL_MODE_IGNITING:  # Igniting
             return HVAC_MODE_HEAT
-        elif state["system_status"] == 3:  # Idle (Power switch on, screen on)
+        elif state == GRILL_MODE_IDLE:  # Idle (Power switch on, screen on)
             return HVAC_MODE_OFF
-        elif state["system_status"] == 2:  # Sleeping (Power switch on, screen off)
+        elif state == GRILL_MODE_SLEEPING:  # Sleeping (Power switch on, screen off)
+            return HVAC_MODE_OFF
+        elif state == GRILL_MODE_OFFLINE:  # Offline
             return HVAC_MODE_OFF
         else:
             return HVAC_MODE_OFF
@@ -136,6 +152,12 @@ class IntegrationBlueprintBinarySensor(ClimateEntity, IntegrationBlueprintEntity
         """
         return (HVAC_MODE_HEAT, HVAC_MODE_OFF, HVAC_MODE_COOL)
 
+    @property
+    def supported_features(self):
+        """Return the list of supported features for the grill"""
+        return SUPPORT_TARGET_TEMPERATURE
+
+    # Climate Methods
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -170,3 +170,8 @@ class TraegerClimateEntity(ClimateEntity, IntegrationBlueprintEntity):
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
         self.client.set_temperature(self.grill_id, temperature)
+
+    def set_hvac_mode(self, hvac_mode):
+        """Start grill shutdown sequence"""
+        if hvac_mode == HVAC_MODE_OFF or hvac_mode == HVAC_MODE_COOL:
+            self.client.shutdown_grill(self.grill_id)

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -68,6 +68,14 @@ class TraegerClimateEntity(ClimateEntity, IntegrationBlueprintEntity):
 
     # Generic Properties
     @property
+    def available(self):
+        """Reports unavailable when the grill is powered off"""
+        if self.grill_state is None:
+            return False
+        else:
+            return True if self.grill_state["connected"] == True else False
+
+    @property
     def name(self):
         """Return the name of the grill"""
         if self.grill_details is None:

--- a/custom_components/traeger/const.py
+++ b/custom_components/traeger/const.py
@@ -23,6 +23,15 @@ CONF_PASSWORD = "password"
 # Defaults
 DEFAULT_NAME = DOMAIN
 
+# Grill Modes
+GRILL_MODE_OFFLINE = 99
+GRILL_MODE_COOL_DOWN = 8
+GRILL_MODE_CUSTOM_COOK = 7
+GRILL_MODE_MANUAL_COOK = 6
+GRILL_MODE_PREHEATING = 5
+GRILL_MODE_IGNITING = 4
+GRILL_MODE_IDLE = 3
+GRILL_MODE_SLEEPING = 2
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/traeger/const.py
+++ b/custom_components/traeger/const.py
@@ -11,9 +11,9 @@ ISSUE_URL = "https://github.com/sebirdman/hass_traeger/issues"
 ICON = "mdi:format-quote-close"
 
 # Platforms
-WATER_HEATER = "water_heater"
+CLIMATE = "climate"
 SENSOR = "sensor"
-PLATFORMS = [WATER_HEATER, SENSOR]
+PLATFORMS = [CLIMATE, SENSOR]
 
 # Configuration and options
 CONF_ENABLED = "enabled"

--- a/custom_components/traeger/manifest.json
+++ b/custom_components/traeger/manifest.json
@@ -6,7 +6,11 @@
   "dependencies": [],
   "config_flow": true,
   "codeowners": [
-    "@sebirdman"
-  ],
-  "requirements": []
+    "@sebirdman",
+    "@Velines",
+    "@krbaker",
+    "@stephenpapierski"
+    ],
+  "requirements": [],
+  "version": "2021.02.0"
 }

--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -55,6 +55,14 @@ class ValueTemperature(IntegrationBlueprintEntity):
 
     # Generic Properties
     @property
+    def available(self):
+        """Reports unavailable when the grill is powered off"""
+        if self.grill_state is None:
+            return False
+        else:
+            return True if self.grill_state["connected"] == True else False
+
+    @property
     def name(self):
         """Return the name of the sensor."""
         return f"{self.value.capitalize()} Temperature"
@@ -106,6 +114,14 @@ class AccessoryTemperatureSensor(IntegrationBlueprintEntity):
         self.schedule_update_ha_state()
 
     # Generic Properties
+    @property
+    def available(self):
+        """Reports unavailable when the grill is powered off"""
+        if self.grill_state is None:
+            return False
+        else:
+            return True if self.grill_state["connected"] == True else False
+
     @property
     def name(self):
         """Return the name of the sensor."""

--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -1,4 +1,6 @@
 """Sensor platform for Traeger."""
+import logging
+
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 
@@ -22,30 +24,39 @@ async def async_setup_entry(hass, entry, async_add_devices):
             return
         for accessory in state["acc"]:
             if accessory["type"] == "probe":
-                async_add_devices([AccessoryTemperatureSensor(
-                    client, grill_id, accessory["uuid"])])
+                async_add_devices(
+                    [AccessoryTemperatureSensor(client, grill_id, accessory["uuid"])]
+                )
 
-        async_add_devices(
-            [ValueTemperature(client, grill["thingName"], "grill")])
-        async_add_devices(
-            [ValueTemperature(client, grill["thingName"], "ambient")])
+        async_add_devices([ValueTemperature(client, grill["thingName"], "grill")])
+        async_add_devices([ValueTemperature(client, grill["thingName"], "ambient")])
+        async_add_devices([PelletSensor(client, grill["thingName"], "pellet_level")])
 
 
 class ValueTemperature(IntegrationBlueprintEntity):
     """Traeger Temperature Value class."""
 
-    def grill_update(self):
-        self.schedule_update_ha_state()
-
     def __init__(self, client, grill_id, value):
         self.grill_id = grill_id
         self.client = client
         self.value = value
+        self.grill_state = None
+        self.grill_units = None
+
+        # Tell the Traeger client to call grill_update() when it gets an update
         self.client.set_callback_for_grill(self.grill_id, self.grill_update)
 
+    def grill_update(self):
+        self.grill_state = self.client.get_state_for_device(self.grill_id)
+        self.grill_units = self.client.get_units_for_device(self.grill_id)
+
+        # Tell HA we have an update
+        self.schedule_update_ha_state()
+
+    # Generic Properties
     @property
     def name(self):
-        """Return the name of the binary_sensor."""
+        """Return the name of the sensor."""
         return f"{self.value.capitalize()} Temperature"
 
     @property
@@ -53,36 +64,55 @@ class ValueTemperature(IntegrationBlueprintEntity):
         return f"{self.grill_id}-{self.value}"
 
     @property
+    def icon(self):
+        return "mdi:thermometer"
+
+    # Sensor Properties
+    @property
     def state(self):
-        state = self.client.get_state_for_device(self.grill_id)
-        if state is None:
+        if self.grill_state is None:
             return 0
-        return state[self.value]
+        return self.grill_state[self.value]
 
     @property
     def unit_of_measurement(self):
-        return self.client.get_units_for_device(self.grill_id)
+        return self.grill_units
 
 
 class AccessoryTemperatureSensor(IntegrationBlueprintEntity):
     """Traeger Temperature Accessory class."""
 
-    def grill_update(self):
-        self.schedule_update_ha_state()
-
     def __init__(self, client, grill_id, sensor_id):
         self.grill_id = grill_id
         self.client = client
         self.sensor_id = sensor_id
+        self.grill_state = None
+        self.grill_units = None
+        self.grill_details = None
+        self.grill_accessory = None
+
+        # Tell the Traeger client to call grill_update() when it gets an update
         self.client.set_callback_for_grill(self.grill_id, self.grill_update)
 
+    def grill_update(self):
+        self.grill_state = self.client.get_state_for_device(self.grill_id)
+        self.grill_units = self.client.get_units_for_device(self.grill_id)
+        self.grill_details = self.client.get_details_for_device(self.grill_id)
+        self.grill_accessory = self.client.get_details_for_accessory(
+            self.grill_id, self.sensor_id
+        )
+
+        # Tell HA we have an update
+        self.schedule_update_ha_state()
+
+    # Generic Properties
     @property
     def name(self):
-        """Return the name of the binary_sensor."""
-        details = self.client.get_details_for_device(self.grill_id)
-        name = details["friendlyName"]
-        if details is None:
+        """Return the name of the sensor."""
+        if self.grill_details is None:
             return f"{self.grill_id}-{self.sensor_id}"
+
+        name = self.grill_details["friendlyName"]
         return f"{name}-{self.sensor_id}"
 
     @property
@@ -90,13 +120,16 @@ class AccessoryTemperatureSensor(IntegrationBlueprintEntity):
         return f"{self.grill_id}-{self.sensor_id}"
 
     @property
+    def icon(self):
+        return "mdi:thermometer"
+
+    # Sensor Properties
+    @property
     def state(self):
-        accessory = self.client.get_details_for_accessory(
-            self.grill_id, self.sensor_id)
-        if accessory is None:
+        if self.grill_accessory is None:
             return 0
-        return accessory["probe"]["get_temp"]
+        return self.grill_accessory["probe"]["get_temp"]
 
     @property
     def unit_of_measurement(self):
-        return self.client.get_units_for_device(self.grill_id)
+        return self.grill_units

--- a/custom_components/traeger/translations/en.json
+++ b/custom_components/traeger/translations/en.json
@@ -22,9 +22,8 @@
         "step": {
             "user": {
                 "data": {
-                    "binary_sensor": "Binary sensor enabled",
-                    "sensor": "Sensor enabled",
-                    "switch": "Switch enabled"
+                    "sensor": "Sensors enabled",
+                    "climate": "Climate entity enabled"
                 }
             }
         }

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Traeger",
     "hacs": "1.6.0",
     "domains": [
-        "water_heater",
+        "climate",
         "sensor"
     ],
     "iot_class": "Cloud Push",

--- a/hacs.json
+++ b/hacs.json
@@ -7,5 +7,12 @@
     ],
     "iot_class": "Cloud Push",
     "render_readme": true,
-    "homeassistant": "0.118.0"
+    "homeassistant": "0.118.0",
+    "version": "2021.02.0",
+    "codeowners": [
+        "@sebirdman",
+        "@Velines",
+        "@krbaker",
+        "@stephenpapierski"
+    ]
 }

--- a/hacs.json
+++ b/hacs.json
@@ -7,12 +7,5 @@
     ],
     "iot_class": "Cloud Push",
     "render_readme": true,
-    "homeassistant": "0.118.0",
-    "version": "0.0.3",
-    "codeowners": [
-        "@sebirdman",
-        "@Velines",
-        "@krbaker",
-        "@stephenpapierski"
-    ]
+    "homeassistant": "0.118.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -8,7 +8,7 @@
     "iot_class": "Cloud Push",
     "render_readme": true,
     "homeassistant": "0.118.0",
-    "version": "2021.02.0",
+    "version": "0.0.3",
     "codeowners": [
         "@sebirdman",
         "@Velines",


### PR DESCRIPTION
### Pellet Level Sensor
Added PelletSensor class that reports back the percentage reported by the grill. I'm not sure if the pellet sensor field is available on a grill without an active pellet sensor, so some additional checks may be necessary here. I can post the contents my messages if need be.
### Properties return values from memory
Per HA docs, "Properties should always only return information from memory and not do I/O (like network requests)". Instead of making a client call each time, I'm having the state variables update in grill_update and simply returning values in the property calls.
### Climate and Temp Sensors Unavailable when Grill is Offline
I found it annoying that the temp and climate sensors got stuck at whatever the last reported value was before the grill got turned off. Those sensors are generally not useful when the grill is offline. I left the pellet sensor available since the last reported value is likely still accurate.
### Shutdown Grill Based on HVAC Mode
Call shutdown_grill() when set_hvac_mode is called with either HVAC_MODE_OFF or HVAC_MODE_COOL. This one is untested. I have an Ironwood 885 and neither the set_temperature() nor the shutdown_grill() calls work for my case. I'm not sure if the calls need to be updated, or if those messages vary per model. If they still work for you (@sebirdman), then it might be time for me to pull out Wireshark on my end.