### PR TITLE
Adding Grill State, Heating State and Probe State Sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,45 @@ Platform | Description
 6. Restart Home Assistant
 7. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Traeger"
 
+## Platform Details
+Some of the platforms are fairly self explanatory, others could use a little more explaining. Below are more details on some of those platforms.
+### Grill State Sensor
+This sensor aligns with the status values in the Traeger app.
+State | Description
+-- | --
+`offline` | Powered off (or not accesible)
+`sleeping` | Standing by (power switch on, screen off)
+`idle` | Standing by (power switch on, screen on)
+`igniting` | Igniting the fire pot
+`preheating` | Ignition is complete, heating to set temperature
+`manual_cook` | Cooking mode
+`custom_cook` | Cooking mode, using preset cook cycle
+`cool_down` | Cool down cycle
+`shutdown` | Cool down cycle complete, heading to sleep
+`unknown` | Unkown state, report to developers
+
+### Heating State Sensor
+This sensor tries to provide more useful insight into the heating status of the grill. Many of these values can be trigger off of to provide notifications that are not available in the Traeger app.
+State | Description
+-- | --
+`idle` | Not in igniting, preheating, cooking or cool_down modes
+`preheating` | Igniting or preheating (and under 165°F)
+`heating` | Trying to get temperature **up** to new target temperature
+`cooling` | Trying to get temperature **down** to new target temperature
+`at_temp` | Temperature has reached the target temperature (and is holding at ±20°F of target temperature)
+`over_temp` | Was `at_temp`, but is now more than 20°F **above** target temperature
+`under_temp` | Was `at_temp`, but is now more than 20°F **below** target temperature
+`cool_down` | Cool down cycle
+
+### Probe State Sensor
+This sensor provides triggers for useful probe events such as being close to the target temperature or reaching the target temperature.
+State | Description
+-- | --
+`idle` | Probe target temperature is **not** set
+`set` | Probe target temperature **is** set
+`close` | Probe temperature is within 5°F of target temperature
+`at_temp` | Probe alarm has fired
+`fell_out` | Probe probably fell out of the meat (Probe temperature is greater that 215°F)
 
 ## Installation (HACS)
 

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -28,38 +28,7 @@ from .const import (
     GRILL_MIN_TEMP_F,
 )
 
-from .entity import TraegerBaseEntity
-
-
-class TraegerGrillMonitor:
-    def __init__(self, client, grill_id, async_add_devices):
-        self.client = client
-        self.grill_id = grill_id
-        self.async_add_devices = async_add_devices
-        self.accessory_status = {}
-
-        self.device_state = self.client.get_state_for_device(self.grill_id)
-        self.grill_add_accessories()
-        self.client.set_callback_for_grill(self.grill_id, self.grill_monitor_internal)
-
-    def grill_monitor_internal(self):
-        self.device_state = self.client.get_state_for_device(self.grill_id)
-        self.grill_add_accessories()
-
-    def grill_add_accessories(self):
-        if self.device_state is None:
-            return
-        for accessory in self.device_state["acc"]:
-            if accessory["type"] == "probe":
-                if accessory["uuid"] not in self.accessory_status:
-                    self.async_add_devices(
-                        [
-                            AccessoryTraegerClimateEntity(
-                                self.client, self.grill_id, accessory["uuid"]
-                            )
-                        ]
-                    )
-                    self.accessory_status[accessory["uuid"]] = True
+from .entity import TraegerBaseEntity, TraegerGrillMonitor
 
 
 async def async_setup_entry(hass, entry, async_add_devices):
@@ -69,7 +38,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
     for grill in grills:
         grill_id = grill["thingName"]
         async_add_devices([TraegerClimateEntity(client, grill_id, "Climate")])
-        TraegerGrillMonitor(client, grill_id, async_add_devices)
+        TraegerGrillMonitor(client, grill_id, async_add_devices, AccessoryTraegerClimateEntity)
 
 
 class TraegerBaseClimate(ClimateEntity, TraegerBaseEntity):

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -274,4 +274,4 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
         """Start grill shutdown sequence"""
         if hvac_mode == HVAC_MODE_OFF or hvac_mode == HVAC_MODE_COOL:
             hvac_mode = hvac_mode
-            # await self.client.shutdown_grill(self.grill_id)
+            #await self.client.shutdown_grill(self.grill_id)

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -24,12 +24,14 @@ from .const import (
     GRILL_MODE_IGNITING,
     GRILL_MODE_IDLE,
     GRILL_MODE_SLEEPING,
+    GRILL_MIN_TEMP_C,
+    GRILL_MIN_TEMP_F,
 )
 
 from .entity import TraegerBaseEntity
 
-class TraegerGrillMonitor():
 
+class TraegerGrillMonitor:
     def __init__(self, client, grill_id, async_add_devices):
         self.client = client
         self.grill_id = grill_id
@@ -51,9 +53,14 @@ class TraegerGrillMonitor():
             if accessory["type"] == "probe":
                 if accessory["uuid"] not in self.accessory_status:
                     self.async_add_devices(
-                        [AccessoryTraegerClimateEntity(self.client, self.grill_id, accessory["uuid"])]
+                        [
+                            AccessoryTraegerClimateEntity(
+                                self.client, self.grill_id, accessory["uuid"]
+                            )
+                        ]
                     )
                     self.accessory_status[accessory["uuid"]] = True
+
 
 async def async_setup_entry(hass, entry, async_add_devices):
     """Setup climate platform."""
@@ -66,7 +73,6 @@ async def async_setup_entry(hass, entry, async_add_devices):
 
 
 class TraegerBaseClimate(ClimateEntity, TraegerBaseEntity):
-
     def __init__(self, client, grill_id, friendly_name):
         super().__init__(client, grill_id)
         self.friendly_name = friendly_name
@@ -96,6 +102,7 @@ class TraegerBaseClimate(ClimateEntity, TraegerBaseEntity):
     def supported_features(self):
         """Return the list of supported features for the grill"""
         return SUPPORT_TARGET_TEMPERATURE
+
 
 class TraegerClimateEntity(TraegerBaseClimate):
     """Climate entity for Traeger grills"""
@@ -141,11 +148,10 @@ class TraegerClimateEntity(TraegerBaseClimate):
 
     @property
     def min_temp(self):
-        # this was the min the traeger app would let me set
         if self.grill_units == TEMP_CELSIUS:
-            return 75
+            return GRILL_MIN_TEMP_C
         else:
-            return 165
+            return GRILL_MIN_TEMP_F
 
     @property
     def hvac_mode(self):
@@ -193,6 +199,7 @@ class TraegerClimateEntity(TraegerBaseClimate):
         """Start grill shutdown sequence"""
         if hvac_mode == HVAC_MODE_OFF or hvac_mode == HVAC_MODE_COOL:
             await self.client.shutdown_grill(self.grill_id)
+
 
 class AccessoryTraegerClimateEntity(TraegerBaseClimate):
     """Climate entity for Traeger grills"""
@@ -298,4 +305,4 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
         """Start grill shutdown sequence"""
         if hvac_mode == HVAC_MODE_OFF or hvac_mode == HVAC_MODE_COOL:
             hvac_mode = hvac_mode
-            #await self.client.shutdown_grill(self.grill_id)
+            # await self.client.shutdown_grill(self.grill_id)

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -24,6 +24,7 @@ from .const import (
     GRILL_MODE_IGNITING,
     GRILL_MODE_IDLE,
     GRILL_MODE_SLEEPING,
+    GRILL_MODE_SHUTDOWN,
     GRILL_MIN_TEMP_C,
     GRILL_MIN_TEMP_F,
 )
@@ -132,21 +133,23 @@ class TraegerClimateEntity(TraegerBaseClimate):
 
         state = self.grill_state["system_status"]
 
-        if state == GRILL_MODE_COOL_DOWN:  # Cool Down
+        if state == GRILL_MODE_COOL_DOWN:
             return HVAC_MODE_COOL
-        elif state == GRILL_MODE_CUSTOM_COOK:  # Custom Cook
+        elif state == GRILL_MODE_CUSTOM_COOK:
             return HVAC_MODE_HEAT
-        elif state == GRILL_MODE_MANUAL_COOK:  # Manual Cook
+        elif state == GRILL_MODE_MANUAL_COOK:
             return HVAC_MODE_HEAT
-        elif state == GRILL_MODE_PREHEATING:  # Preheating
+        elif state == GRILL_MODE_PREHEATING:
             return HVAC_MODE_HEAT
-        elif state == GRILL_MODE_IGNITING:  # Igniting
+        elif state == GRILL_MODE_IGNITING:
             return HVAC_MODE_HEAT
-        elif state == GRILL_MODE_IDLE:  # Idle (Power switch on, screen on)
+        elif state == GRILL_MODE_IDLE:
             return HVAC_MODE_OFF
-        elif state == GRILL_MODE_SLEEPING:  # Sleeping (Power switch on, screen off)
+        elif state == GRILL_MODE_SLEEPING:
             return HVAC_MODE_OFF
-        elif state == GRILL_MODE_OFFLINE:  # Offline
+        elif state == GRILL_MODE_OFFLINE:
+            return HVAC_MODE_OFF
+        elif state == GRILL_MODE_SHUTDOWN:
             return HVAC_MODE_OFF
         else:
             return HVAC_MODE_OFF

--- a/custom_components/traeger/const.py
+++ b/custom_components/traeger/const.py
@@ -35,6 +35,11 @@ GRILL_MODE_IGNITING = 4
 GRILL_MODE_IDLE = 3
 GRILL_MODE_SLEEPING = 2
 
+# Grill Temps
+# these are the min temps the traeger app would set
+GRILL_MIN_TEMP_C = 75
+GRILL_MIN_TEMP_F = 165
+
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------
 {NAME}

--- a/custom_components/traeger/const.py
+++ b/custom_components/traeger/const.py
@@ -26,14 +26,15 @@ CONF_PASSWORD = "password"
 DEFAULT_NAME = DOMAIN
 
 # Grill Modes
-GRILL_MODE_OFFLINE = 99
-GRILL_MODE_COOL_DOWN = 8
-GRILL_MODE_CUSTOM_COOK = 7
-GRILL_MODE_MANUAL_COOK = 6
-GRILL_MODE_PREHEATING = 5
-GRILL_MODE_IGNITING = 4
-GRILL_MODE_IDLE = 3
-GRILL_MODE_SLEEPING = 2
+GRILL_MODE_OFFLINE = 99     # Offline
+GRILL_MODE_SHUTDOWN = 9     # Cooled down, heading to sleep
+GRILL_MODE_COOL_DOWN = 8    # Cool down cycle
+GRILL_MODE_CUSTOM_COOK = 7  # Custom cook
+GRILL_MODE_MANUAL_COOK = 6  # Manual cook
+GRILL_MODE_PREHEATING = 5   # Preheating
+GRILL_MODE_IGNITING = 4     # Igniting
+GRILL_MODE_IDLE = 3         # Idle (Power switch on, screen on)
+GRILL_MODE_SLEEPING = 2     # Sleeping (Power switch on, screen off)
 
 # Grill Temps
 # these are the min temps the traeger app would set

--- a/custom_components/traeger/entity.py
+++ b/custom_components/traeger/entity.py
@@ -61,7 +61,7 @@ class TraegerBaseEntity(Entity):
         }
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return {
             "attribution": ATTRIBUTION,

--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -304,11 +304,15 @@ class ProbeState(TraegerBaseSensor):
         elif target_changed and target_temp != 0:
             self.probe_alarm = False
 
-        if self.probe_alarm or probe_temp >= target_temp:
-            state = "at_temp"
-        elif target_temp != 0 and self.grill_state in self.active_modes:
+        if target_temp != 0 and grill_mode in self.active_modes:
+            fell_out_temp = 102 if self.grill_units == TEMP_CELSIUS else 215
             close_temp = 3 if self.grill_units == TEMP_CELSIUS else 5
-            if probe_temp + close_temp >= target_temp:
+
+            if probe_temp >= fell_out_temp:
+                state = "fell_out"
+            elif self.probe_alarm or probe_temp >= target_temp:
+                state = "at_temp"
+            elif probe_temp + close_temp >= target_temp:
                 state = "close"
             else:
                 state = "set"

--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -5,9 +5,20 @@ from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from .const import (
     DEFAULT_NAME,
     DOMAIN,
+    GRILL_MODE_OFFLINE,
+    GRILL_MODE_COOL_DOWN,
+    GRILL_MODE_CUSTOM_COOK,
+    GRILL_MODE_MANUAL_COOK,
+    GRILL_MODE_PREHEATING,
+    GRILL_MODE_IGNITING,
+    GRILL_MODE_IDLE,
+    GRILL_MODE_SLEEPING,
+    GRILL_MIN_TEMP_C,
+    GRILL_MIN_TEMP_F,
 )
 
 from .entity import TraegerBaseEntity
+
 
 async def async_setup_entry(hass, entry, async_add_devices):
     """Setup sensor platform."""
@@ -15,10 +26,12 @@ async def async_setup_entry(hass, entry, async_add_devices):
     grills = client.get_grills()
     for grill in grills:
         grill_id = grill["thingName"]
-        async_add_devices([PelletSensor(client, grill["thingName"], "Pellet Level",  "pellet_level")])
+        async_add_devices([PelletSensor(client, grill["thingName"], "Pellet Level", "pellet_level")])
         async_add_devices([ValueTemperature(client, grill["thingName"], "Ambient Temperature", "ambient")])
         async_add_devices([GrillTimer(client, grill["thingName"], "Cook Timer Start", "cook_timer_start")])
         async_add_devices([GrillTimer(client, grill["thingName"], "Cook Timer End", "cook_timer_end")])
+        async_add_devices([GrillState(client, grill["thingName"], "Grill State", "grill_state")])
+        async_add_devices([HeatingState(client, grill["thingName"], "Heating State", "heating_state")])
 
 
 class TraegerBaseSensor(TraegerBaseEntity):
@@ -91,6 +104,7 @@ class PelletSensor(TraegerBaseSensor):
     def unit_of_measurement(self):
         return "%"
 
+
 class GrillTimer(TraegerBaseSensor):
     """Traeger Timer class."""
 
@@ -103,3 +117,125 @@ class GrillTimer(TraegerBaseSensor):
     @property
     def unit_of_measurement(self):
         return "sec"
+
+
+class GrillState(TraegerBaseSensor):
+    """Traeger Grill State class.
+    These states correlate with the Traeger application.
+    """
+
+    # Generic Properties
+    @property
+    def icon(self):
+        return "mdi:grill"
+
+    # Sensor Properties
+    @property
+    def state(self):
+
+        state = self.grill_state["system_status"]
+
+        if state == GRILL_MODE_COOL_DOWN:  # Cool Down
+            return "cool_down"
+        elif state == GRILL_MODE_CUSTOM_COOK:  # Custom Cook
+            return "cook_custom"
+        elif state == GRILL_MODE_MANUAL_COOK:  # Manual Cook
+            return "cook_manual"
+        elif state == GRILL_MODE_PREHEATING:  # Preheating
+            return "preheating"
+        elif state == GRILL_MODE_IGNITING:  # Igniting
+            return "igniting"
+        elif state == GRILL_MODE_IDLE:  # Idle (Power switch on, screen on)
+            return "idle"
+        elif state == GRILL_MODE_SLEEPING:  # Sleeping (Power switch on, screen off)
+            return "sleeping"
+        elif state == GRILL_MODE_OFFLINE:  # Offline
+            return "offline"
+        else:
+            return "offline"
+
+
+class HeatingState(TraegerBaseSensor):
+    """Traeger Heating State class."""
+
+    def __init__(self, client, grill_id, friendly_name, value):
+        super().__init__(client, grill_id, friendly_name, value)
+        self.previous_target_temp = None
+        self.previous_state = "idle"
+        self.preheat_modes = [GRILL_MODE_PREHEATING, GRILL_MODE_IGNITING]
+        self.cook_modes = [GRILL_MODE_CUSTOM_COOK, GRILL_MODE_MANUAL_COOK]
+
+    # Generic Properties
+    @property
+    def icon(self):
+        if self.state == "over_temp":
+            return "mdi:fire-alert"
+        else:
+            return "mdi:fire"
+
+    # Sensor Properties
+    @property
+    def state(self):
+        if self.grill_state is None:
+            return "idle"
+
+        target_temp = self.grill_state["set"]
+        grill_mode = self.grill_state["system_status"]
+        current_temp = self.grill_state["grill"]
+        target_changed = True if target_temp != self.previous_target_temp else False
+        min_cook_temp = (
+            GRILL_MIN_TEMP_C if self.grill_units == TEMP_CELSIUS else GRILL_MIN_TEMP_F
+        )
+        temp_swing = 11 if self.grill_units == TEMP_CELSIUS else 20
+        low_temp = target_temp - temp_swing
+        high_temp = target_temp + temp_swing
+
+        if grill_mode in self.preheat_modes:
+            if current_temp < min_cook_temp:
+                state = "preheating"
+            else:
+                state = "heating"
+        elif grill_mode in self.cook_modes:
+            if self.previous_state == "heating":
+                if current_temp >= target_temp:
+                    state = "at_temp"
+                else:
+                    state = "heating"
+            elif self.previous_state == "cooling":
+                if current_temp <= target_temp:
+                    state = "at_temp"
+                else:
+                    state = "cooling"
+            elif self.previous_state == "at_temp":
+                if current_temp > high_temp:
+                    state = "over_temp"
+                elif current_temp < low_temp:
+                    state = "under_temp"
+                else:
+                    state = "at_temp"
+            elif self.previous_state == "under_temp":
+                if current_temp > low_temp:
+                    state = "at_temp"
+                else:
+                    state = "under_temp"
+            elif self.previous_state == "over_temp":
+                if current_temp < high_temp:
+                    state = "at_temp"
+                else:
+                    state = "over_temp"
+            # Catch all if coming from idle or preheating
+            else:
+                target_changed = True
+
+            if target_changed:
+                if current_temp <= target_temp:
+                    state = "heating"
+                else:
+                    state = "cooling"
+        else:
+            state = "idle"
+
+        self.previous_target_temp = target_temp
+        self.previous_state = state
+
+        return state

--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -13,6 +13,7 @@ from .const import (
     GRILL_MODE_IGNITING,
     GRILL_MODE_IDLE,
     GRILL_MODE_SLEEPING,
+    GRILL_MODE_SHUTDOWN,
     GRILL_MIN_TEMP_C,
     GRILL_MIN_TEMP_F,
 )
@@ -136,22 +137,24 @@ class GrillState(TraegerBaseSensor):
 
         state = self.grill_state["system_status"]
 
-        if state == GRILL_MODE_COOL_DOWN:  # Cool Down
+        if state == GRILL_MODE_COOL_DOWN:
             return "cool_down"
-        elif state == GRILL_MODE_CUSTOM_COOK:  # Custom Cook
+        elif state == GRILL_MODE_CUSTOM_COOK:
             return "cook_custom"
-        elif state == GRILL_MODE_MANUAL_COOK:  # Manual Cook
+        elif state == GRILL_MODE_MANUAL_COOK:
             return "cook_manual"
-        elif state == GRILL_MODE_PREHEATING:  # Preheating
+        elif state == GRILL_MODE_PREHEATING:
             return "preheating"
-        elif state == GRILL_MODE_IGNITING:  # Igniting
+        elif state == GRILL_MODE_IGNITING:
             return "igniting"
-        elif state == GRILL_MODE_IDLE:  # Idle (Power switch on, screen on)
+        elif state == GRILL_MODE_IDLE:
             return "idle"
-        elif state == GRILL_MODE_SLEEPING:  # Sleeping (Power switch on, screen off)
+        elif state == GRILL_MODE_SLEEPING:
             return "sleeping"
-        elif state == GRILL_MODE_OFFLINE:  # Offline
+        elif state == GRILL_MODE_OFFLINE:
             return "offline"
+        elif state == GRILL_MODE_SHUTDOWN:
+            return "shutdown"
         else:
             return "unknown"    # Likely a new state we don't know about
 


### PR DESCRIPTION
Sensor Overview
- Grill State aligns with Traeger app states
- Heating State tries to provide more actionable events such as reaching new target temps (even after initial preheat), overheating issue, etc
- Probe State tries to provide actionable events such as probe temp being close to target temp , probe temp reaching target temp and probe likely fell out of meat

Other Notes
- Fixed release badge in README (currently reports no releases/repo found)
- Discovered previous undocumented `shutdown` mode (Grill goes to shutdown mode between `cool_down` and `sleep`
- Probe State sensor should theoretically work on new Traeger Timberline with dual probes, but I don't have a way to test that
- Closes #37 