### PR TITLE
Temperature Presets for Probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ State | Description
 This sensor provides triggers for useful probe events such as being close to the target temperature or reaching the target temperature.
 State | Description
 -- | --
-`idle` | Probe target temperature is **not** set
+`idle` | Probe target temperature is **not** set (or grill is not in igniting, preheating or cooking modes)
 `set` | Probe target temperature **is** set
 `close` | Probe temperature is within 5°F of target temperature
 `at_temp` | Probe alarm has fired

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -187,7 +187,7 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
         )
         self.current_preset_mode = PRESET_NONE
 
-        # Tell the Traeger client to call grill_update() when it gets an update
+        # Tell the Traeger client to call grill_accessory_update() when it gets an update
         self.client.set_callback_for_grill(self.grill_id, self.grill_accessory_update)
 
     def grill_accessory_update(self):
@@ -207,10 +207,10 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
     @property
     def available(self):
         """Reports unavailable when the grill is powered off"""
-        if self.grill_state is None:
+        if self.grill_accessory is None:
             return False
         else:
-            return True if self.grill_state["probe_con"] == 1 else False
+            return self.grill_accessory["con"]
 
     @property
     def unique_id(self):
@@ -245,9 +245,9 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
     def min_temp(self):
         # this was the min the traeger would let me set
         if self.grill_units == TEMP_CELSIUS:
-            return 45
+            return 27
         else:
-            return 115
+            return 80
 
     @property
     def hvac_mode(self):
@@ -257,7 +257,7 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
         if self.grill_state is None:
             return HVAC_MODE_OFF
 
-        state = self.grill_state["probe_con"]
+        state = self.grill_accessory["con"]
 
         if state == 1:  # Probe Connected
             return HVAC_MODE_HEAT

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -207,7 +207,9 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
     @property
     def available(self):
         """Reports unavailable when the grill is powered off"""
-        if self.grill_accessory is None:
+        if (self.grill_state is None
+                or self.grill_state["connected"] == False
+                or self.grill_accessory is None):
             return False
         else:
             return self.grill_accessory["con"]

--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -29,6 +29,7 @@ from .const import (
     GRILL_MODE_SHUTDOWN,
     GRILL_MIN_TEMP_C,
     GRILL_MIN_TEMP_F,
+    PROBE_PRESET_MODES,
 )
 
 from .entity import TraegerBaseEntity, TraegerGrillMonitor
@@ -185,80 +186,6 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
             self.grill_id, self.sensor_id
         )
         self.current_preset_mode = PRESET_NONE
-        self.available_preset_modes = {
-                "Chicken": {
-                    TEMP_FAHRENHEIT: 165,
-                    TEMP_CELSIUS: 74,
-                    },
-                "Turkey": {
-                    TEMP_FAHRENHEIT: 165,
-                    TEMP_CELSIUS: 74,
-                    },
-                "Beef (Rare)": {
-                    TEMP_FAHRENHEIT: 125,
-                    TEMP_CELSIUS: 52,
-                    },
-                "Beef (Medium Rare)": {
-                    TEMP_FAHRENHEIT: 135,
-                    TEMP_CELSIUS: 57,
-                    },
-                "Beef (Medium)": {
-                    TEMP_FAHRENHEIT: 140,
-                    TEMP_CELSIUS: 60,
-                    },
-                "Beef (Medium Well)": {
-                    TEMP_FAHRENHEIT: 145,
-                    TEMP_CELSIUS: 63,
-                    },
-                "Beef (Well Done)": {
-                    TEMP_FAHRENHEIT: 155,
-                    TEMP_CELSIUS: 68,
-                    },
-                "Beef (Ground)": {
-                    TEMP_FAHRENHEIT: 160,
-                    TEMP_CELSIUS: 71,
-                    },
-                "Lamb (Rare)": {
-                    TEMP_FAHRENHEIT: 125,
-                    TEMP_CELSIUS: 52,
-                    },
-                "Lamb (Medium Rare)": {
-                    TEMP_FAHRENHEIT: 135,
-                    TEMP_CELSIUS: 57,
-                    },
-                "Lamb (Medium)": {
-                    TEMP_FAHRENHEIT: 140,
-                    TEMP_CELSIUS: 60,
-                    },
-                "Lamb (Medium Well)": {
-                    TEMP_FAHRENHEIT: 145,
-                    TEMP_CELSIUS: 63,
-                    },
-                "Lamb (Well Done)": {
-                    TEMP_FAHRENHEIT: 155,
-                    TEMP_CELSIUS: 68,
-                    },
-                "Lamb (Ground)": {
-                    TEMP_FAHRENHEIT: 160,
-                    TEMP_CELSIUS: 71,
-                    },
-                "Pork (Medium Rare)": {
-                    TEMP_FAHRENHEIT: 135,
-                    TEMP_CELSIUS: 57,
-                    },
-                "Pork (Medium)": {
-                    TEMP_FAHRENHEIT: 140,
-                    TEMP_CELSIUS: 60,
-                    },
-                "Pork (Well Done)": {
-                    TEMP_FAHRENHEIT: 155,
-                    TEMP_CELSIUS: 68,
-                    },
-                "Fish": {
-                    TEMP_FAHRENHEIT: 145,
-                    TEMP_CELSIUS: 63,
-                    },
-                }
 
         # Tell the Traeger client to call grill_update() when it gets an update
         self.client.set_callback_for_grill(self.grill_id, self.grill_accessory_update)
@@ -356,7 +283,7 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
 
     @property
     def preset_modes(self):
-        return list(self.available_preset_modes.keys())
+        return list(PROBE_PRESET_MODES.keys())
 
     @property
     def supported_features(self):
@@ -379,5 +306,5 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode"""
         self.current_preset_mode = preset_mode
-        temperature = self.available_preset_modes[preset_mode][self.grill_units]
+        temperature = PROBE_PRESET_MODES[preset_mode][self.grill_units]
         await self.client.set_probe_temperature(self.grill_id, round(temperature))

--- a/custom_components/traeger/const.py
+++ b/custom_components/traeger/const.py
@@ -1,3 +1,8 @@
+from homeassistant.const import (
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
+
 """Constants for traeger."""
 # Base component constants
 NAME = "Traeger"
@@ -40,6 +45,82 @@ GRILL_MODE_SLEEPING = 2     # Sleeping (Power switch on, screen off)
 # these are the min temps the traeger app would set
 GRILL_MIN_TEMP_C = 75
 GRILL_MIN_TEMP_F = 165
+
+# Probe Preset Modes
+PROBE_PRESET_MODES = {
+        "Chicken": {
+            TEMP_FAHRENHEIT: 165,
+            TEMP_CELSIUS: 74,
+            },
+        "Turkey": {
+            TEMP_FAHRENHEIT: 165,
+            TEMP_CELSIUS: 74,
+            },
+        "Beef (Rare)": {
+            TEMP_FAHRENHEIT: 125,
+            TEMP_CELSIUS: 52,
+            },
+        "Beef (Medium Rare)": {
+            TEMP_FAHRENHEIT: 135,
+            TEMP_CELSIUS: 57,
+            },
+        "Beef (Medium)": {
+            TEMP_FAHRENHEIT: 140,
+            TEMP_CELSIUS: 60,
+            },
+        "Beef (Medium Well)": {
+            TEMP_FAHRENHEIT: 145,
+            TEMP_CELSIUS: 63,
+            },
+        "Beef (Well Done)": {
+            TEMP_FAHRENHEIT: 155,
+            TEMP_CELSIUS: 68,
+            },
+        "Beef (Ground)": {
+            TEMP_FAHRENHEIT: 160,
+            TEMP_CELSIUS: 71,
+            },
+        "Lamb (Rare)": {
+            TEMP_FAHRENHEIT: 125,
+            TEMP_CELSIUS: 52,
+            },
+        "Lamb (Medium Rare)": {
+            TEMP_FAHRENHEIT: 135,
+            TEMP_CELSIUS: 57,
+            },
+        "Lamb (Medium)": {
+            TEMP_FAHRENHEIT: 140,
+            TEMP_CELSIUS: 60,
+            },
+        "Lamb (Medium Well)": {
+            TEMP_FAHRENHEIT: 145,
+            TEMP_CELSIUS: 63,
+            },
+        "Lamb (Well Done)": {
+            TEMP_FAHRENHEIT: 155,
+            TEMP_CELSIUS: 68,
+            },
+        "Lamb (Ground)": {
+            TEMP_FAHRENHEIT: 160,
+            TEMP_CELSIUS: 71,
+            },
+        "Pork (Medium Rare)": {
+            TEMP_FAHRENHEIT: 135,
+            TEMP_CELSIUS: 57,
+            },
+        "Pork (Medium)": {
+            TEMP_FAHRENHEIT: 140,
+            TEMP_CELSIUS: 60,
+            },
+        "Pork (Well Done)": {
+            TEMP_FAHRENHEIT: 155,
+            TEMP_CELSIUS: 68,
+            },
+        "Fish": {
+            TEMP_FAHRENHEIT: 145,
+            TEMP_CELSIUS: 63,
+            },
+        }
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -252,12 +252,14 @@ class ProbeState(TraegerBaseSensor):
     def __init__(self, client, grill_id, sensor_id):
         super().__init__(client, grill_id, f"Probe State {sensor_id}", f"probe_state_{sensor_id}")
         self.sensor_id = sensor_id
-        self.grill_accessory = self.client.get_details_for_accessory(self.grill_id, self.sensor_id)
+        self.grill_accessory = self.client.get_details_for_accessory(
+            self.grill_id, self.sensor_id
+        )
         self.previous_target_temp = None
         self.probe_alarm = False
         self.active_modes = [GRILL_MODE_PREHEATING, GRILL_MODE_IGNITING, GRILL_MODE_CUSTOM_COOK, GRILL_MODE_MANUAL_COOK]
 
-        # Tell the Traeger client to call grill_update() when it gets an update
+        # Tell the Traeger client to call grill_accessory_update() when it gets an update
         self.client.set_callback_for_grill(self.grill_id, self.grill_accessory_update)
 
     def grill_accessory_update(self):

--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -280,7 +280,9 @@ class ProbeState(TraegerBaseSensor):
     def available(self):
         """Reports unavailable when the probe is not connected"""
 
-        if self.grill_accessory is None:
+        if (self.grill_state is None
+                or self.grill_state["connected"] == False
+                or self.grill_accessory is None):
             # Reset probe alarm if accessory becomes unavailable
             self.probe_alarm = False
             return False


### PR DESCRIPTION
- Added temperature presets (meat temps) to probe climate
- Align variables referenced between probe climate and probe sensor entities
- Fixed issue where probe alarm wasn't resetting
- Updated min target probe temp to 80°F
- Closes #44 