### PR TITLE
Add meat temperature presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ State | Description
 This sensor provides triggers for useful probe events such as being close to the target temperature or reaching the target temperature.
 State | Description
 -- | --
-`idle` | Probe target temperature is **not** set
+`idle` | Probe target temperature is **not** set (or grill is not in igniting, preheating or cooking modes)
 `set` | Probe target temperature **is** set
 `close` | Probe temperature is within 5°F of target temperature
 `at_temp` | Probe alarm has fired

--- a/custom_components/traeger/const.py
+++ b/custom_components/traeger/const.py
@@ -1,3 +1,8 @@
+from homeassistant.const import (
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
+
 """Constants for traeger."""
 # Base component constants
 NAME = "Traeger"
@@ -40,6 +45,82 @@ GRILL_MODE_SLEEPING = 2     # Sleeping (Power switch on, screen off)
 # these are the min temps the traeger app would set
 GRILL_MIN_TEMP_C = 75
 GRILL_MIN_TEMP_F = 165
+
+# Probe Preset Modes
+PROBE_PRESET_MODES = {
+        "Chicken": {
+            TEMP_FAHRENHEIT: 165,
+            TEMP_CELSIUS: 74,
+            },
+        "Turkey": {
+            TEMP_FAHRENHEIT: 165,
+            TEMP_CELSIUS: 74,
+            },
+        "Beef (Rare)": {
+            TEMP_FAHRENHEIT: 125,
+            TEMP_CELSIUS: 52,
+            },
+        "Beef (Medium Rare)": {
+            TEMP_FAHRENHEIT: 135,
+            TEMP_CELSIUS: 57,
+            },
+        "Beef (Medium)": {
+            TEMP_FAHRENHEIT: 140,
+            TEMP_CELSIUS: 60,
+            },
+        "Beef (Medium Well)": {
+            TEMP_FAHRENHEIT: 145,
+            TEMP_CELSIUS: 63,
+            },
+        "Beef (Well Done)": {
+            TEMP_FAHRENHEIT: 155,
+            TEMP_CELSIUS: 68,
+            },
+        "Beef (Ground)": {
+            TEMP_FAHRENHEIT: 160,
+            TEMP_CELSIUS: 71,
+            },
+        "Lamb (Rare)": {
+            TEMP_FAHRENHEIT: 125,
+            TEMP_CELSIUS: 52,
+            },
+        "Lamb (Medium Rare)": {
+            TEMP_FAHRENHEIT: 135,
+            TEMP_CELSIUS: 57,
+            },
+        "Lamb (Medium)": {
+            TEMP_FAHRENHEIT: 140,
+            TEMP_CELSIUS: 60,
+            },
+        "Lamb (Medium Well)": {
+            TEMP_FAHRENHEIT: 145,
+            TEMP_CELSIUS: 63,
+            },
+        "Lamb (Well Done)": {
+            TEMP_FAHRENHEIT: 155,
+            TEMP_CELSIUS: 68,
+            },
+        "Lamb (Ground)": {
+            TEMP_FAHRENHEIT: 160,
+            TEMP_CELSIUS: 71,
+            },
+        "Pork (Medium Rare)": {
+            TEMP_FAHRENHEIT: 135,
+            TEMP_CELSIUS: 57,
+            },
+        "Pork (Medium)": {
+            TEMP_FAHRENHEIT: 140,
+            TEMP_CELSIUS: 60,
+            },
+        "Pork (Well Done)": {
+            TEMP_FAHRENHEIT: 155,
+            TEMP_CELSIUS: 68,
+            },
+        "Fish": {
+            TEMP_FAHRENHEIT: 145,
+            TEMP_CELSIUS: 63,
+            },
+        }
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------


### PR DESCRIPTION
Added meat temperature presets to the probe climate entity. Presets
include options such as Chicken, Beef (Medium), Pork (Well Done),
etc. Other changes include...
 - Fix issue where probe alarm was not resetting
 - Align probe state sensor and climate to pull information from
   same system variables
 - Clarify description of `idle` for probe state sensor in README
 - Updated min target probe temp to 80°F

Closes #44 