### PR TITLE
Fix availability of super smoke

### DIFF
--- a/custom_components/traeger/const.py
+++ b/custom_components/traeger/const.py
@@ -41,6 +41,10 @@ GRILL_MODE_SLEEPING = 2     # Sleeping (Power switch on, screen off)
 GRILL_MIN_TEMP_C = 75
 GRILL_MIN_TEMP_F = 165
 
+# Super Smoke is available until this temperature
+SUPER_SMOKE_MAX_TEMP_C = 107
+SUPER_SMOKE_MAX_TEMP_F = 225
+
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------
 {NAME}

--- a/custom_components/traeger/switch.py
+++ b/custom_components/traeger/switch.py
@@ -1,10 +1,13 @@
 """Switch platform for Traeger."""
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 
 from .const import (
     DOMAIN,
     GRILL_MODE_CUSTOM_COOK,
     GRILL_MODE_IGNITING,
+    SUPER_SMOKE_MAX_TEMP_C,
+    SUPER_SMOKE_MAX_TEMP_F,
 )
 
 from .entity import TraegerBaseEntity
@@ -115,5 +118,9 @@ class TraegerSuperSmokeEntity(TraegerSwitchEntity):
             return False
         else:
             if GRILL_MODE_IGNITING <= self.grill_state['system_status'] <= GRILL_MODE_CUSTOM_COOK:
-                return True if self.grill_features["super_smoke_enabled"] == 1 else False
+                super_smoke_supported = self.grill_features["super_smoke_enabled"] == 1
+                super_smoke_max_temp = SUPER_SMOKE_MAX_TEMP_C if self.grill_units == TEMP_CELSIUS else SUPER_SMOKE_MAX_TEMP_F
+                super_smoke_within_temp = self.grill_state["set"] <= super_smoke_max_temp
+                
+                return super_smoke_supported and super_smoke_within_temp
         return False

--- a/hacs.json
+++ b/hacs.json
@@ -1,10 +1,6 @@
 {
     "name": "Traeger",
     "hacs": "1.6.0",
-    "domains": [
-        "climate",
-        "sensor"
-    ],
     "iot_class": "Cloud Push",
     "render_readme": true,
     "homeassistant": "0.118.0"

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,6 @@
 {
     "name": "Traeger",
     "hacs": "1.6.0",
-    "iot_class": "Cloud Push",
     "render_readme": true,
     "homeassistant": "0.118.0"
 }


### PR DESCRIPTION
Super smoke is only available on the grill below 225 degrees F. The availability of the super smoke switch now reflects that.

Closes #46 