### PR TITLE
Add support for more accessories

### DIFF
--- a/custom_components/traeger/climate.py
+++ b/custom_components/traeger/climate.py
@@ -227,13 +227,15 @@ class AccessoryTraegerClimateEntity(TraegerBaseClimate):
     def current_temperature(self):
         if self.grill_accessory is None:
             return 0
-        return self.grill_accessory["probe"]["get_temp"]
+        acc_type = self.grill_accessory["type"]
+        return self.grill_accessory[acc_type]["get_temp"]
 
     @property
     def target_temperature(self):
         if self.grill_accessory is None:
             return 0
-        return self.grill_accessory["probe"]["set_temp"]
+        acc_type = self.grill_accessory["type"]
+        return self.grill_accessory[acc_type]["set_temp"]
 
     @property
     def max_temp(self):

--- a/custom_components/traeger/entity.py
+++ b/custom_components/traeger/entity.py
@@ -88,7 +88,7 @@ class TraegerGrillMonitor:
         if self.device_state is None:
             return
         for accessory in self.device_state["acc"]:
-            if accessory["type"] == "probe":
+            if accessory["type"] in ["probe", "btprobe", "hob"]:
                 if accessory["uuid"] not in self.accessory_status:
                     if self.probe_entity:
                         self.async_add_devices([self.probe_entity(self.client, self.grill_id, accessory["uuid"])])

--- a/custom_components/traeger/sensor.py
+++ b/custom_components/traeger/sensor.py
@@ -307,14 +307,17 @@ class ProbeState(TraegerBaseSensor):
         if self.grill_accessory is None:
             return "idle"
 
-        target_temp = self.grill_accessory["probe"]["set_temp"]
-        probe_temp = self.grill_accessory["probe"]["get_temp"]
+        acc_type = self.grill_accessory["type"]
+        target_temp = self.grill_accessory[acc_type]["set_temp"]
+        probe_temp = self.grill_accessory[acc_type]["get_temp"]
         target_changed = target_temp != self.previous_target_temp
         grill_mode = self.grill_state["system_status"]
         fell_out_temp = 102 if self.grill_units == TEMP_CELSIUS else 215
 
         # Latch probe alarm, reset if target changed or grill leaves active modes
-        if self.grill_accessory["probe"]["alarm_fired"]:
+        if "alarm_fired" not in self.grill_accessory[acc_type]:
+            self.probe_alarm = False
+        elif self.grill_accessory[acc_type]["alarm_fired"]:
             self.probe_alarm = True
         elif ((target_changed and target_temp != 0)
                 or (grill_mode not in self.active_modes)):


### PR DESCRIPTION
Thanks for the integration! Been working great w/ no hassle

The new Timberline / Timberline XL grills support a few extra accessories out of the box, namely an induction cooktop (hob) and a bluetooth probes. These show up under `acc`, but the `type` isn't `"probe"` and properties are slightly different. 

Sample snippet pulled from the MQTT topic:

```json
    "acc": [
      {
        "channel": "bt",
        "hob": {
          "fw": "01.00.55",
          "level": 0,
          "get_temp": 35,
          "set_temp": 0,
          "status": 0
        },
        "type": "hob",
        "uuid": "xxxxxxxxxxxx",
        "con": 1
      },
      {
        "channel": "BT0",
        "btprobe": {
          "batt": 8,
          "fw": "XX.YY.ZZ",
          "alarm_fired": 0,
          "get_temp": 129,
          "set_temp": 155,
          "ambient_temp": 1542
        },
        "type": "btprobe",
        "uuid": "xxxxxxxxxxxx",
        "con": 1
      }
    ],
```

This PR adds support for those additional known-good extra accessories